### PR TITLE
Oppgraderer Distroless til nodejs18-debian12@sha256:c2de6dd6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs18-debian12@sha256:ee36c135f8391f1facc373d9e9c0445fde06b0ab45c514ef33b84163fe7ec14b
+FROM gcr.io/distroless/nodejs18-debian12@sha256:c2de6dd6f5f8ddbfc977b1f16b5a121017f3bf11e9993baa922aa18322c2bf24
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
Fra flex-cli